### PR TITLE
Support primary_source

### DIFF
--- a/common/file_model/variant.py
+++ b/common/file_model/variant.py
@@ -31,8 +31,17 @@ class Variant ():
         return []
     
     def get_primary_source(self) -> Mapping:
+        """
+        Fetches source from variant INFO columns
+        Fallsback to fetching from the header
+        """
+        
         try:
-            source = self.header.get_lines("source")[0].value
+            if "SOURCE" in self.info:
+                source = self.info["SOURCE"]
+            else:
+                source = self.header.get_lines("source")[0].value
+
             if re.search("^dbSNP", source):
                 source_id = "dbSNP"
                 source_name = "dbSNP"
@@ -46,27 +55,27 @@ class Variant ():
                 source_description = "ClinVar db of human variants"
                 source_url = "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
                 source_release = ""
+            
+            elif re.search("^EVA", source):
+                source_id = "EVA"
+                source_name = "EVA"
+                source_description = "European Variation Archive"
+                source_url = "https://www.ebi.ac.uk/eva"
+                source_url_id = "https://www.ebi.ac.uk/eva/?variant&accessionID="
+                source_release = ""
 
-        except:
+        except Exception as e:
             return None 
 
         return {
-            "accession_id": self.name,
-            "name": self.name,
-            "description": "",
-            "assignment_method": {
-                                "type": "DIRECT",
-                                "description": "A reference made by an external resource of annotation to an Ensembl feature that Ensembl imports without modification"
-                            },
-            "url": f"{source_url}{self.name}",
-            "source": {
+            
                         "id" : f"{source_id}",
                         "name": f"{source_name}",
                         "description": f"{source_description}",
                         "url":  f"{source_url}",
                         "release": f"{source_release}"
-                        }
-        }
+                }
+        
 
     def set_allele_type(self, alt_one_bp: bool, ref_one_bp: bool, ref_alt_equal_bp: bool):         
         match [alt_one_bp, ref_one_bp, ref_alt_equal_bp]:

--- a/common/file_model/variant.py
+++ b/common/file_model/variant.py
@@ -65,7 +65,7 @@ class Variant ():
                 source_name = "Ensembl"
                 source_description = "Ensembl"
                 source_url = "https://beta.ensembl.org"
-                source_url_id = ""
+                source_url_id = "https://beta.ensembl.org"
                 source_release = "110" # to be fetched from the file
                 variant_id = f"{self.chromosome}:{self.position}:{self.name}"
             

--- a/common/file_model/variant.py
+++ b/common/file_model/variant.py
@@ -47,14 +47,9 @@ class Variant ():
                 source_name = "dbSNP"
                 source_description = "NCBI db of human variants"
                 source_url = "https://www.ncbi.nlm.nih.gov/snp/"
-                source_release =154
-
-            elif re.search("^ClinVar", source):
-                source_id = "ClinVar"
-                source_name = "ClinVar"
-                source_description = "ClinVar db of human variants"
-                source_url = "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
-                source_release = ""
+                source_url_id = source_url
+                source_release = 154
+                variant_id = self.name
             
             elif re.search("^EVA", source):
                 source_id = "EVA"
@@ -62,7 +57,19 @@ class Variant ():
                 source_description = "European Variation Archive"
                 source_url = "https://www.ebi.ac.uk/eva"
                 source_url_id = "https://www.ebi.ac.uk/eva/?variant&accessionID="
-                source_release = ""
+                source_release = "release_5"
+                variant_id = self.name
+
+            elif re.search("^Ensembl", source):
+                source_id = "Ensembl"
+                source_name = "Ensembl"
+                source_description = "Ensembl"
+                source_url = "https://beta.ensembl.org"
+                assembly = "" #to be fetched from the file
+                source_url_id = f"https://beta.ensembl.org/genome-browser/{assembly}?focus=variant:"
+                source_release = "110" #to be fetched from the file
+                variant_id = f"{self.chromosome}:{self.position}:{self.name}"
+            
 
         except Exception as e:
             return None 
@@ -75,7 +82,7 @@ class Variant ():
                                 "type": "DIRECT",
                                 "description": "A reference made by an external resource of annotation to an Ensembl feature that Ensembl imports without modification"
                             },
-            "url": f"{source_url}{self.name}",
+            "url": f"{source_url_id}{variant_id}",
             "source": {
 
                         "id" : f"{source_id}",

--- a/common/file_model/variant.py
+++ b/common/file_model/variant.py
@@ -68,13 +68,25 @@ class Variant ():
             return None 
 
         return {
-            
+            "accession_id": self.name,
+            "name": self.name,
+            "description": "",
+            "assignment_method": {
+                                "type": "DIRECT",
+                                "description": "A reference made by an external resource of annotation to an Ensembl feature that Ensembl imports without modification"
+                            },
+            "url": f"{source_url}{self.name}",
+            "source": {
+
                         "id" : f"{source_id}",
                         "name": f"{source_name}",
                         "description": f"{source_description}",
                         "url":  f"{source_url}",
                         "release": f"{source_release}"
-                }
+                        }
+        }
+
+
         
 
     def set_allele_type(self, alt_one_bp: bool, ref_one_bp: bool, ref_alt_equal_bp: bool):         

--- a/common/file_model/variant.py
+++ b/common/file_model/variant.py
@@ -48,7 +48,7 @@ class Variant ():
                 source_description = "NCBI db of human variants"
                 source_url = "https://www.ncbi.nlm.nih.gov/snp/"
                 source_url_id = source_url
-                source_release = 154
+                source_release = 156
                 variant_id = self.name
             
             elif re.search("^EVA", source):
@@ -65,10 +65,11 @@ class Variant ():
                 source_name = "Ensembl"
                 source_description = "Ensembl"
                 source_url = "https://beta.ensembl.org"
-                assembly = "" #to be fetched from the file
+                assembly = "" # to be fetched from the file
                 source_url_id = f"https://beta.ensembl.org/genome-browser/{assembly}?focus=variant:"
-                source_release = "110" #to be fetched from the file
+                source_release = "110" # to be fetched from the file
                 variant_id = f"{self.chromosome}:{self.position}:{self.name}"
+            
             
 
         except Exception as e:

--- a/common/file_model/variant.py
+++ b/common/file_model/variant.py
@@ -65,8 +65,7 @@ class Variant ():
                 source_name = "Ensembl"
                 source_description = "Ensembl"
                 source_url = "https://beta.ensembl.org"
-                assembly = "" # to be fetched from the file
-                source_url_id = f"https://beta.ensembl.org/genome-browser/{assembly}?focus=variant:"
+                source_url_id = ""
                 source_release = "110" # to be fetched from the file
                 variant_id = f"{self.chromosome}:{self.position}:{self.name}"
             


### PR DESCRIPTION
API fetched primary_source from the header previously. Modified logic to check from INFO column first and then fallback to fetching from the header.

