### PR TITLE
Fixing score fields for GERP and CADD according to VDM

### DIFF
--- a/common/file_model/variant.py
+++ b/common/file_model/variant.py
@@ -211,7 +211,7 @@ class Variant ():
         if self.get_info_key_index("Conservation") is not None:
             gerp_index = self.get_info_key_index("Conservation") 
             gerp_prediction_result = {
-                    "result": csq_record_list[gerp_index]  ,
+                    "score": csq_record_list[gerp_index]  ,
                     "analysis_method": {
                         "tool": "GERP",
                         "qualifier": "GERP"

--- a/common/file_model/variant.py
+++ b/common/file_model/variant.py
@@ -211,7 +211,7 @@ class Variant ():
         if self.get_info_key_index("Conservation") is not None:
             gerp_index = self.get_info_key_index("Conservation") 
             gerp_prediction_result = {
-                    "score": float(csq_record_list[gerp_index])  ,
+                    "score": csq_record_list[gerp_index] ,
                     "analysis_method": {
                         "tool": "GERP",
                         "qualifier": "GERP"

--- a/common/file_model/variant.py
+++ b/common/file_model/variant.py
@@ -211,7 +211,7 @@ class Variant ():
         if self.get_info_key_index("Conservation") is not None:
             gerp_index = self.get_info_key_index("Conservation") 
             gerp_prediction_result = {
-                    "score": csq_record_list[gerp_index]  ,
+                    "score": float(csq_record_list[gerp_index])  ,
                     "analysis_method": {
                         "tool": "GERP",
                         "qualifier": "GERP"

--- a/common/file_model/variant_allele.py
+++ b/common/file_model/variant_allele.py
@@ -76,7 +76,7 @@ class VariantAllele():
         if "cadd_phred" in prediction_index_map.keys():
             if not self.prediction_result_already_exists(current_prediction_results, "CADD"):
                 cadd_prediction_result = {
-                        "result": csq_record[prediction_index_map["cadd_phred"]] ,
+                        "score": csq_record[prediction_index_map["cadd_phred"]] ,
                         "analysis_method": {
                             "tool": "CADD",
                             "qualifier": "CADD"

--- a/common/file_model/variant_allele.py
+++ b/common/file_model/variant_allele.py
@@ -76,7 +76,7 @@ class VariantAllele():
         if "cadd_phred" in prediction_index_map.keys():
             if not self.prediction_result_already_exists(current_prediction_results, "CADD"):
                 cadd_prediction_result = {
-                        "score": float(csq_record[prediction_index_map["cadd_phred"]]) ,
+                        "score": csq_record[prediction_index_map["cadd_phred"]] ,
                         "analysis_method": {
                             "tool": "CADD",
                             "qualifier": "CADD"

--- a/common/file_model/variant_allele.py
+++ b/common/file_model/variant_allele.py
@@ -76,7 +76,7 @@ class VariantAllele():
         if "cadd_phred" in prediction_index_map.keys():
             if not self.prediction_result_already_exists(current_prediction_results, "CADD"):
                 cadd_prediction_result = {
-                        "score": csq_record[prediction_index_map["cadd_phred"]] ,
+                        "score": float(csq_record[prediction_index_map["cadd_phred"]]) ,
                         "analysis_method": {
                             "tool": "CADD",
                             "qualifier": "CADD"


### PR DESCRIPTION
CADD and GERP scores are returned in prediction_result->result
According to [VDM](https://github.com/Ensembl/ensembl-vdm-docs/blob/main/src/docs/prediction_result.md), they should be in prediction_result->score

