### PR TITLE
Bug fix for empty population allele frequencies

### DIFF
--- a/common/file_model/population_metadata.json
+++ b/common/file_model/population_metadata.json
@@ -265,7 +265,7 @@
         },
         {
         "name": "1000GENOMES:phase_3:MXL",
-        "description": "Colombian in Medellin, Colombia",
+        "description": "Mexican Ancestry in Los Angeles, California",
         "type": "regional",
         "is_global": false,
         "display_group_name": "1000 Genomes Project Phase 3",

--- a/common/file_model/variant.py
+++ b/common/file_model/variant.py
@@ -294,7 +294,8 @@ class Variant ():
             pop_names.extend([sub_pop["name"] for sub_pop in pop])
         hpmaf = []
         pop_frequency_map = self.traverse_population_info()
-
+        if not pop_frequency_map:
+            return pop_frequency_map 
         for pop_name in pop_names:
             by_population = []
             for allele in allele_list:
@@ -323,7 +324,6 @@ class Variant ():
                             if pop_name == pop_freq["population_name"] and pop_freq["allele_frequency"]:
                                 minimised_allele = allele.minimise_allele(allele.alt)
                                 by_population.append([float(pop_freq["allele_frequency"]),minimised_allele, pop_name])               
-
             by_population_sorted = sorted(by_population, key=lambda item: item[0])
             if len(by_population_sorted) >= 2:
                 highest_frequency = by_population_sorted[-1][0]

--- a/common/file_model/variant.py
+++ b/common/file_model/variant.py
@@ -322,11 +322,7 @@ class Variant ():
                         for pop_freq in pop_freqs:
                             if pop_name == pop_freq["population_name"] and pop_freq["allele_frequency"]:
                                 minimised_allele = allele.minimise_allele(allele.alt)
-                                by_population.append([float(pop_freq["allele_frequency"]),minimised_allele, pop_name])
-                else:
-                    return {}
-            
-                
+                                by_population.append([float(pop_freq["allele_frequency"]),minimised_allele, pop_name])               
 
             by_population_sorted = sorted(by_population, key=lambda item: item[0])
             if len(by_population_sorted) >= 2:

--- a/common/file_model/variant.py
+++ b/common/file_model/variant.py
@@ -300,29 +300,31 @@ class Variant ():
             for allele in allele_list:
                 if allele.minimise_allele(allele.alt) in pop_frequency_map:
                     pop_freqs = pop_frequency_map[allele.minimise_allele(allele.alt)].values()
-                # Calculate reference allele from parsed frequency info of all alleles
-                if allele.get_allele_type()["accession_id"] == "biological_region" and len(by_population)>0 :
-                     allele_frequency_ref = 1 - sum(list(zip(*by_population))[0])
-                     if allele_frequency_ref <= 1 and allele_frequency_ref >= 0:
-                        population_frequency_ref = {
-                                                "population_name": pop_name,
-                                                "allele_frequency": allele_frequency_ref ,
-                                                "allele_count": None,
-                                                "allele_number": None,
-                                                "is_minor_allele": False,
-                                                "is_hpmaf": False
-                                            }
-                        minimised_allele = allele.minimise_allele(allele.alt)
-                        if minimised_allele not in pop_frequency_map:
-                            pop_frequency_map[minimised_allele] = {}
-                        pop_frequency_map[minimised_allele][pop_name] = population_frequency_ref
-                        by_population.append([allele_frequency_ref,minimised_allele,pop_name])
-                
-                else:       
-                    for pop_freq in pop_freqs:
-                        if pop_name == pop_freq["population_name"] and pop_freq["allele_frequency"]:
+                    # Calculate reference allele from parsed frequency info of all alleles
+                    if allele.get_allele_type()["accession_id"] == "biological_region" and len(by_population)>0 :
+                        allele_frequency_ref = 1 - sum(list(zip(*by_population))[0])
+                        if allele_frequency_ref <= 1 and allele_frequency_ref >= 0:
+                            population_frequency_ref = {
+                                                    "population_name": pop_name,
+                                                    "allele_frequency": allele_frequency_ref ,
+                                                    "allele_count": None,
+                                                    "allele_number": None,
+                                                    "is_minor_allele": False,
+                                                    "is_hpmaf": False
+                                                }
                             minimised_allele = allele.minimise_allele(allele.alt)
-                            by_population.append([float(pop_freq["allele_frequency"]),minimised_allele, pop_name])
+                            if minimised_allele not in pop_frequency_map:
+                                pop_frequency_map[minimised_allele] = {}
+                            pop_frequency_map[minimised_allele][pop_name] = population_frequency_ref
+                            by_population.append([allele_frequency_ref,minimised_allele,pop_name])
+                    
+                    else:       
+                        for pop_freq in pop_freqs:
+                            if pop_name == pop_freq["population_name"] and pop_freq["allele_frequency"]:
+                                minimised_allele = allele.minimise_allele(allele.alt)
+                                by_population.append([float(pop_freq["allele_frequency"]),minimised_allele, pop_name])
+                else:
+                    return {}
             
                 
 

--- a/common/file_model/variant_allele.py
+++ b/common/file_model/variant_allele.py
@@ -76,46 +76,6 @@ class VariantAllele():
             current_prediction_results = info_map[csq_record_list[prediction_index_map["allele"]]]["prediction_results"] 
             info_map[csq_record_list[prediction_index_map["allele"]]]["prediction_results"] += self.create_allele_prediction_results(current_prediction_results, csq_record_list, prediction_index_map)
         return info_map
-    
-    # def traverse_population_info(self) -> Mapping:
-    #     directory = os.path.dirname(__file__)
-    #     with open(os.path.join(directory,'populations.json')) as pop_file:
-    #         pop_mapping = json.load(pop_file)
-    #     population_frequency_map = {}
-    #     for csq_record in self.variant.info["CSQ"]:
-    #         csq_record_list = csq_record.split("|")
-    #         allele_index = self.variant.get_info_key_index("Allele") 
-    #         if csq_record_list[allele_index] is not None:
-    #             if csq_record_list[allele_index] not in population_frequency_map.keys():
-    #                 population_frequency_map[csq_record_list[allele_index]] = {}
-    #             for pop_key, pop in pop_mapping.items():
-    #                 for sub_pop in pop:
-    #                     if sub_pop["name"] in population_frequency_map[csq_record_list[allele_index]]:
-    #                         continue
-    #                     allele_count = allele_number = allele_frequency = None
-    #                     for freq_key, freq_val in sub_pop["frequencies"].items():
-    #                         col_index = self.variant.get_info_key_index(freq_val)
-    #                     if col_index is not None and csq_record_list[col_index] is not None:
-    #                         if freq_key == "af":
-    #                             allele_frequency = csq_record_list[col_index] 
-    #                         elif freq_key == "an":
-    #                             allele_number = csq_record_list[col_index] or None
-    #                         elif freq_key == "ac":
-    #                             allele_count = csq_record_list[col_index] or None
-    #                         else:
-    #                             raise Exception('Frequency metric is not recognised')
-    #                         population_frequency = {
-    #                                             "population": sub_pop["name"],
-    #                                             "allele_frequency": allele_frequency or -1,
-    #                                             "allele_count": allele_count,
-    #                                             "allele_number": allele_number,
-    #                                             "is_minor_allele": False,
-    #                                             "is_hpmaf": False
-    #                                         }
-
-    #                         population_frequency_map[csq_record_list[allele_index]][sub_pop["name"]] = population_frequency
-    #     return population_frequency_map
-
      
     def create_allele_prediction_results(self, current_prediction_results: Mapping, csq_record: List, prediction_index_map: dict) -> list:
         prediction_results = []
@@ -253,16 +213,16 @@ class VariantAllele():
             }
 
     
-    def minimise_allele(self, alt: str):
+    def minimise_allele(self, alt: str) -> str:
         """
         VCF file has the representation without anchoring bases
         for prediction scores in INFO column. This function is useful
         in matching the SPDI format in VCF with the allele in memory
         """
-        minimised_allele = alt
+        minimised_allele_string = alt
         if len(alt) > len(self.variant.ref):
-            minimised_allele = alt[1:] 
+            minimised_allele_string = alt[1:] 
         elif len(alt) < len(self.variant.ref):
-            minimised_allele = "-"
-        return minimised_allele
+            minimised_allele_string = "-"
+        return minimised_allele_string
     

--- a/graphql_service/resolver/variant_model.py
+++ b/graphql_service/resolver/variant_model.py
@@ -169,6 +169,6 @@ def resolve_populations(_: None, info: GraphQLResolveInfo, genome_id: str = None
     population_metadata_file = f"{current_directory}/../../common/file_model/population_metadata.json"
     with open(population_metadata_file) as pop_file:
             population_metadata = json.load(pop_file)
-    return population_metadata[genome_id]
+    return population_metadata.get(genome_id,[]) 
 
 


### PR DESCRIPTION
When population allele frequencies are empty in the file, we return an empty array for all alleles including reference allele