### PR TITLE
run pipeline only on main branch

### DIFF
--- a/gitlab-ci-templates/.templates.yml
+++ b/gitlab-ci-templates/.templates.yml
@@ -1,4 +1,3 @@
-
 # stages for the pipeline
 stages:
   - build_docker
@@ -18,7 +17,11 @@ variables:
 
 # Deploy to webteam k8s cluster
 .web-rules:
-  - if: '$CI_DEPLOY_FREEZE == null && $CI_PROJECT_NAMESPACE== "ensembl-web"'
+  - if: '$CI_DEPLOY_FREEZE == null && $CI_PROJECT_NAMESPACE== "ensembl-web" && $CI_COMMIT_BRANCH == "main"'
+
+# Deploy to webteam k8s cluster
+.web-branch-rules:
+  - if: '$CI_DEPLOY_FREEZE == null && $CI_PROJECT_NAMESPACE== "ensembl-web" && $CI_COMMIT_BRANCH != "main"'
 
 # Deploy to variation team k8s cluster
 .variation-rules:

--- a/gitlab-ci-templates/.web-gitlab-ci.yml
+++ b/gitlab-ci-templates/.web-gitlab-ci.yml
@@ -6,6 +6,8 @@ include: '/gitlab-ci-templates/.templates.yml'
 # Job to build docker image
 Build:Docker-Image:
   extends: .build
+  rules:
+    - !reference [.web-rules]
 
 
 # Job to deploy to the live environment
@@ -15,7 +17,6 @@ Live:Web:HL:
     BASE: k8s/overlays/webteam/hl
   rules:
     - !reference [.web-rules]
-    - !reference [.rules]
   environment:
     name: wp40-hl-prod
 
@@ -26,7 +27,6 @@ Live:Web:HX:
     BASE: k8s/overlays/webteam/hx
   rules:
     - !reference [.web-rules]
-    - !reference [.rules]
   environment:
     name: wp41-hx-prod
 
@@ -37,7 +37,6 @@ Staging:Web:HL:
     BASE: k8s/overlays/webteam/hl
   rules:
     - !reference [.web-rules]
-    - !reference [.rules]
   environment:
     name: wp40-hl-staging
 
@@ -47,7 +46,6 @@ Internal:Web:HL:
     BASE: k8s/overlays/webteam/hl
   rules:
     - !reference [.web-rules]
-    - !reference [.rules]
   environment:
     name: wp40-hl-internal
 
@@ -57,7 +55,6 @@ Dev:Web:HL:
     BASE: k8s/overlays/webteam/hl
   rules:
     - !reference [.web-rules]
-    - !reference [.rules]
   environment:
     name: wp40-hl-development
 
@@ -67,6 +64,5 @@ Dev:Web:HX:
     BASE: k8s/overlays/webteam/hx
   rules:
     - !reference [.web-rules]
-    - !reference [.rules]
   environment:
     name: wp41-hx-development


### PR DESCRIPTION
# Introduction 
PR to run pipeline only on main branch

# Description
The current pipeline is not honouring the rules for the web team to build/deploy pieplein only on main branch and it should not trigger pipeline on non-main branch. This triggers deployment to live environment on the non main branch as well which breaks the live environment.

The rules array is not working possibly due to known issue with the rules syntax as highlighted here 
https://gitlab.com/gitlab-org/gitlab/-/issues/322992

Change the web-rules to include branch ( main ) and use only web-rules.

