### PR TITLE
Bug fix to returning empty ref allele population frequency

### DIFF
--- a/common/file_model/variant.py
+++ b/common/file_model/variant.py
@@ -344,29 +344,29 @@ class Variant ():
             for allele in allele_list:
                 if allele.minimise_allele(allele.alt) in pop_frequency_map:
                     pop_freqs = pop_frequency_map[allele.minimise_allele(allele.alt)].values()
-                    # Calculate reference allele from parsed frequency info of all alleles
-                    if allele.get_allele_type()["accession_id"] == "biological_region" and len(by_population)>0 :
-                        allele_frequency_ref = 1 - sum(list(zip(*by_population))[0])
-                        if allele_frequency_ref <= 1 and allele_frequency_ref >= 0:
-                            population_frequency_ref = {
-                                                    "population_name": pop_name,
-                                                    "allele_frequency": allele_frequency_ref ,
-                                                    "allele_count": None,
-                                                    "allele_number": None,
-                                                    "is_minor_allele": False,
-                                                    "is_hpmaf": False
-                                                }
+                    for pop_freq in pop_freqs:
+                        if pop_name == pop_freq["population_name"] and pop_freq["allele_frequency"]:
                             minimised_allele = allele.minimise_allele(allele.alt)
-                            if minimised_allele not in pop_frequency_map:
-                                pop_frequency_map[minimised_allele] = {}
-                            pop_frequency_map[minimised_allele][pop_name] = population_frequency_ref
-                            by_population.append([allele_frequency_ref,minimised_allele,pop_name])
-                    
-                    else:       
-                        for pop_freq in pop_freqs:
-                            if pop_name == pop_freq["population_name"] and pop_freq["allele_frequency"]:
-                                minimised_allele = allele.minimise_allele(allele.alt)
-                                by_population.append([float(pop_freq["allele_frequency"]),minimised_allele, pop_name])               
+                            by_population.append([float(pop_freq["allele_frequency"]),minimised_allele, pop_name]) 
+
+                # Calculate reference allele from parsed frequency info of all alleles
+                if allele.get_allele_type()["accession_id"] == "biological_region" and len(by_population)>0 :
+                    allele_frequency_ref = 1 - sum(list(zip(*by_population))[0])
+                    if allele_frequency_ref <= 1 and allele_frequency_ref >= 0:
+                        population_frequency_ref = {
+                                                "population_name": pop_name,
+                                                "allele_frequency": allele_frequency_ref ,
+                                                "allele_count": None,
+                                                "allele_number": None,
+                                                "is_minor_allele": False,
+                                                "is_hpmaf": False
+                                            }
+                        minimised_allele = allele.minimise_allele(allele.alt)
+                        if minimised_allele not in pop_frequency_map:
+                            pop_frequency_map[minimised_allele] = {}
+                        pop_frequency_map[minimised_allele][pop_name] = population_frequency_ref
+                        by_population.append([allele_frequency_ref,minimised_allele,pop_name])
+                            
             by_population_sorted = sorted(by_population, key=lambda item: item[0])
             if len(by_population_sorted) >= 2:
                 highest_frequency = by_population_sorted[-1][0]

--- a/common/file_model/variant.py
+++ b/common/file_model/variant.py
@@ -312,15 +312,16 @@ class Variant ():
                                     allele_count = csq_record_list[col_index] or None
                                 else:
                                     raise Exception('Frequency metric is not recognised')
-                                population_frequency = {
+                                
+                                if allele_frequency is not None:
+                                    population_frequency = {
                                                     "population_name": sub_pop["name"],
-                                                    "allele_frequency": allele_frequency,
+                                                    "allele_frequency": float(allele_frequency),
                                                     "allele_count": allele_count,
                                                     "allele_number": allele_number,
                                                     "is_minor_allele": False,
                                                     "is_hpmaf": False
                                                 }
-                                if allele_frequency:
                                     population_frequency_map[csq_record_list[allele_index]][sub_pop["name"]] = population_frequency
         return population_frequency_map
     
@@ -345,7 +346,7 @@ class Variant ():
                 if allele.minimise_allele(allele.alt) in pop_frequency_map:
                     pop_freqs = pop_frequency_map[allele.minimise_allele(allele.alt)].values()
                     for pop_freq in pop_freqs:
-                        if pop_name == pop_freq["population_name"] and pop_freq["allele_frequency"]:
+                        if pop_name == pop_freq["population_name"] and pop_freq["allele_frequency"] is not None:
                             minimised_allele = allele.minimise_allele(allele.alt)
                             by_population.append([float(pop_freq["allele_frequency"]),minimised_allele, pop_name]) 
 
@@ -364,9 +365,9 @@ class Variant ():
                         minimised_allele = allele.minimise_allele(allele.alt)
                         if minimised_allele not in pop_frequency_map:
                             pop_frequency_map[minimised_allele] = {}
-                        pop_frequency_map[minimised_allele][pop_name] = population_frequency_ref
-                        by_population.append([allele_frequency_ref,minimised_allele,pop_name])
                             
+                        pop_frequency_map[minimised_allele][pop_name] = population_frequency_ref
+                        by_population.append([allele_frequency_ref,minimised_allele,pop_name])             
             by_population_sorted = sorted(by_population, key=lambda item: item[0])
             if len(by_population_sorted) >= 2:
                 highest_frequency = by_population_sorted[-1][0]

--- a/graphql_service/ariadne_app.py
+++ b/graphql_service/ariadne_app.py
@@ -34,7 +34,7 @@ def prepare_executable_schema() -> GraphQLSchema:
         schema,
         QUERY_TYPE,
         VARIANT_TYPE,
-        VARIANT_ALLELE_TYPE,
+        VARIANT_ALLELE_TYPE
     )
 
 

--- a/graphql_service/ariadne_app.py
+++ b/graphql_service/ariadne_app.py
@@ -18,12 +18,6 @@ from graphql import GraphQLSchema
 from starlette.requests import Request
 from ariadne import ScalarType
 
-# Serializing float to return exponent notation
-float_scalar = ScalarType("Float")
-@float_scalar.serializer
-def serialize_float(value):
-    return f"{value:.3e}"
-
 from graphql_service.resolver.variant_model import (
     QUERY_TYPE,
     VARIANT_TYPE,
@@ -41,7 +35,6 @@ def prepare_executable_schema() -> GraphQLSchema:
         QUERY_TYPE,
         VARIANT_TYPE,
         VARIANT_ALLELE_TYPE,
-        float_scalar
     )
 
 

--- a/graphql_service/ariadne_app.py
+++ b/graphql_service/ariadne_app.py
@@ -16,6 +16,13 @@ from typing import Dict, Callable
 import ariadne
 from graphql import GraphQLSchema
 from starlette.requests import Request
+from ariadne import ScalarType
+
+# Serializing float to return exponent notation
+float_scalar = ScalarType("Float")
+@float_scalar.serializer
+def serialize_float(value):
+    return f"{value:.3e}"
 
 from graphql_service.resolver.variant_model import (
     QUERY_TYPE,
@@ -33,7 +40,8 @@ def prepare_executable_schema() -> GraphQLSchema:
         schema,
         QUERY_TYPE,
         VARIANT_TYPE,
-        VARIANT_ALLELE_TYPE
+        VARIANT_ALLELE_TYPE,
+        float_scalar
     )
 
 


### PR DESCRIPTION
- [x] Test examples 
     - [x] 1:230710048:rs699 (bi-allelic snp)
     - [x] 13:32379902:rs202155613 (multi-allelic snp)
     - [x] 13:57932508:rs71197234 (insertion)
     - [x] 1:10123:rs1639546401 (deletion)
     - [x] 1:10153:rs1639547929 (indel)
     -  [x] 13:32379902:rs202155613 
     -  [x] 21:45988447:rs1312342906
- [x] Return allele_frequency as exponential value: Decided to be done at client side, changes related to precision will be added in a subsequent PR
- [x] Refactoring code to improve speed