### PR TITLE
Improve parsing of phenotypes to reduce execution time

### DIFF
--- a/common/file_model/variant_allele.py
+++ b/common/file_model/variant_allele.py
@@ -62,19 +62,27 @@ class VariantAllele():
         info_map = {}
         for csq_record in self.variant.info["CSQ"]:
             csq_record_list = csq_record.split("|")
-            if csq_record_list[prediction_index_map["allele"]] not in info_map.keys():
-                info_map[csq_record_list[prediction_index_map["allele"]]] = {"phenotype_assertions": [], "predicted_molecular_consequences": [], "prediction_results": []} 
+            allele = csq_record_list[prediction_index_map["allele"]]
 
-            phenotypes = csq_record_list[prediction_index_map["phenotypes"]].split("&") if "phenotypes" in prediction_index_map.keys() else []   
-            for phenotype in phenotypes:
-                phenotype_assertions = self.create_allele_phenotype_assertion(phenotype) if phenotype else []
-                if (phenotype_assertions):
-                    info_map[csq_record_list[prediction_index_map["allele"]]]["phenotype_assertions"].append(phenotype_assertions)
+            if allele not in info_map.keys():
+                info_map[allele] = {"phenotype_assertions": [], "predicted_molecular_consequences": [], "prediction_results": []} 
+
+            # parse and form phenotypes
+            if not info_map[allele]["phenotype_assertions"]:
+                phenotypes = csq_record_list[prediction_index_map["phenotypes"]].split("&") if "phenotypes" in prediction_index_map.keys() else []   
+                for phenotype in phenotypes:
+                    phenotype_assertions = self.create_allele_phenotype_assertion(phenotype) if phenotype else []
+                    if (phenotype_assertions):
+                        info_map[allele]["phenotype_assertions"].append(phenotype_assertions)
+            
+            # parse and form molecular consequences
             predicted_molecular_consequences = self.create_allele_predicted_molecular_consequence(csq_record_list, prediction_index_map)
             if (predicted_molecular_consequences):
-                info_map[csq_record_list[prediction_index_map["allele"]]]["predicted_molecular_consequences"].append(predicted_molecular_consequences)
-            current_prediction_results = info_map[csq_record_list[prediction_index_map["allele"]]]["prediction_results"] 
-            info_map[csq_record_list[prediction_index_map["allele"]]]["prediction_results"] += self.create_allele_prediction_results(current_prediction_results, csq_record_list, prediction_index_map)
+                info_map[allele]["predicted_molecular_consequences"].append(predicted_molecular_consequences)
+            
+            # parse and form prediction results
+            current_prediction_results = info_map[allele]["prediction_results"] 
+            info_map[allele]["prediction_results"] += self.create_allele_prediction_results(current_prediction_results, csq_record_list, prediction_index_map)
         return info_map
      
     def create_allele_prediction_results(self, current_prediction_results: Mapping, csq_record: List, prediction_index_map: dict) -> list:
@@ -181,7 +189,11 @@ class VariantAllele():
         return (result, score)
     
     def create_allele_phenotype_assertion(self, phenotype: str) -> Mapping:
-        phenotype_name,source,feature = phenotype.split("+")
+        splits = phenotype.split("+")
+        if len(splits) != 3 or splits[2].startswith("ENS"):
+            return None
+
+        phenotype_name,source,feature = splits
         evidence_list = []
         if re.search("^ENS.*G\d+", feature):
             feature_type = "Gene"
@@ -190,15 +202,7 @@ class VariantAllele():
         elif re.search("^rs", feature):
             feature_type = "Variant"  
         else:
-            feature_type = None 
-        # if source:
-        #     evidence =  {
-        #         "source": {
-        #             "id": source,
-        #             "name": source.replace("_"," ") 
-        #         }
-        #     }
-        #     evidence_list.append(evidence)
+            feature_type = None
         
         if phenotype:
             return {

--- a/common/file_model/variant_allele.py
+++ b/common/file_model/variant_allele.py
@@ -67,7 +67,7 @@ class VariantAllele():
             if allele not in info_map.keys():
                 info_map[allele] = {"phenotype_assertions": [], "predicted_molecular_consequences": [], "prediction_results": []} 
 
-            # parse and form phenotypes
+            # parse and form phenotypes - adding phenotype from any of the csq record would be enough for adding only variant-linked phenotypes
             if not info_map[allele]["phenotype_assertions"]:
                 phenotypes = csq_record_list[prediction_index_map["phenotypes"]].split("&") if "phenotypes" in prediction_index_map.keys() else []   
                 for phenotype in phenotypes:


### PR DESCRIPTION
### Background
In the ensembl-hypsipyle payload some variants are returning large number of phenotype and causing a run time increase. An investigation is done in this ticket on run time issue - [ENSVAR-6230](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6230) 

The number of phenotype itself seems problematic as it turns out we are adding redundant phenotype information. For example, we would have same variant-linked phenotype for any transcript that a variant overlap. But we are adding same phenotype from each of the transcript (the output have a entries for each phenotype). 

### Fixes
- Do not add phenotype if already added for an allele.
- Only add variant-linked phenotype.
- Add a check if we correctly have 3 fields from each phenotype entry.

### Test cases
- `13:32379902:rs202155613` (shows 15 phenotype but supposed to show 11. Extra 4 from different variants - to be fixed in data file)
- `17:28367840:rs704`  (shows 974 variants but supposed to show 1326. Reduced because Phenotype plugin removes redundant records - can be fixed later on if we show more details other than phenotype name and source).