### PR TITLE
Updating Predicted Molecular Consequences for EV

### DIFF
--- a/common/file_model/variant.py
+++ b/common/file_model/variant.py
@@ -315,7 +315,7 @@ class Variant ():
                                 if allele_frequency is not None:
                                     population_frequency = {
                                                     "population_name": sub_pop["name"],
-                                                    "allele_frequency": float(allele_frequency),
+                                                    "allele_frequency": float('%.3g' % float(allele_frequency)),
                                                     "allele_count": allele_count,
                                                     "allele_number": allele_number,
                                                     "is_minor_allele": False,
@@ -357,7 +357,7 @@ class Variant ():
             if allele_frequency_ref <= 1 and allele_frequency_ref >= 0:
                 population_frequency_ref = {
                                                 "population_name": pop_name,
-                                                "allele_frequency": allele_frequency_ref ,
+                                                "allele_frequency": float('%.3g' % float(allele_frequency_ref)) ,
                                                 "allele_count": None,
                                                 "allele_number": None,
                                                 "is_minor_allele": False,

--- a/common/file_model/variant_allele.py
+++ b/common/file_model/variant_allele.py
@@ -132,7 +132,7 @@ class VariantAllele():
         consequences_list = []
         if "consequence" in prediction_index_map.keys():
             for cons in csq_record[prediction_index_map["consequence"]].split("&"):
-                if cons in ["downstream_gene_variant", "upstream_gene_variant", "intergenic_variant", "regulatory_region_variant"]:
+                if cons in ["downstream_gene_variant", "upstream_gene_variant", "intergenic_variant", "regulatory_region_variant", "TF_binding_site_variant"]:
                     consequences_list = []
                     break
                 consequences_list.append(
@@ -252,7 +252,6 @@ class VariantAllele():
                 "gene_stable_id" : csq_record[prediction_index_map["gene"]], 
                 "gene_symbol": csq_record[prediction_index_map["symbol"]], 
                 "transcript_biotype": csq_record[prediction_index_map["biotype"]], 
-                "protein_stable_id": "protein_id_placeholder",
                 "prediction_results": prediction_results,
                 "cdna_location": cdna_location,
                 "cds_location": cds_location,
@@ -324,11 +323,7 @@ class VariantAllele():
         in matching the SPDI format in VCF with the allele in memory
         """
         minimised_allele_string = alt
-        if len(alt) > len(self.reference_sequence):
-            minimised_allele_string = alt[1:] 
-        elif len(alt) < len(self.reference_sequence):
-            minimised_allele_string = "-"
-        elif alt == self.reference_sequence and len(self.alt) != len(self.reference_sequence):
+        if self.reference_sequence[0] == alt[0]:
             minimised_allele_string = alt[1:] if len(alt) > 1 else "-"
         return minimised_allele_string
     

--- a/common/file_model/variant_allele.py
+++ b/common/file_model/variant_allele.py
@@ -173,7 +173,7 @@ class VariantAllele():
             cdna_start = cdna_position_list[0]
             cdna_end = cdna_start if len(cdna_position_list) < 2 else cdna_position_list[1]
             cdna_length = int(cdna_end) - int(cdna_start) + 1
-            ref_sequence = self.reference_sequence
+            ref_sequence = self.minimise_allele(self.reference_sequence)
             alt_sequence = csq_record[prediction_index_map["allele"]]
             cdna_location = {
                 "start": cdna_start,
@@ -302,9 +302,11 @@ class VariantAllele():
         in matching the SPDI format in VCF with the allele in memory
         """
         minimised_allele_string = alt
-        if len(alt) > len(self.variant.ref):
+        if len(alt) > len(self.reference_sequence):
             minimised_allele_string = alt[1:] 
-        elif len(alt) < len(self.variant.ref):
+        elif len(alt) < len(self.reference_sequence):
             minimised_allele_string = "-"
+        elif alt == self.reference_sequence:
+            minimised_allele_string = alt[1:]
         return minimised_allele_string
     

--- a/common/file_model/variant_allele.py
+++ b/common/file_model/variant_allele.py
@@ -121,7 +121,7 @@ class VariantAllele():
                     break
                 consequences_list.append(
                     {
-                        "accession_id": cons
+                        "value": cons
                     }
                 )
 
@@ -223,8 +223,8 @@ class VariantAllele():
             return {
                 "allele_name": csq_record[prediction_index_map["allele"]],
                 "stable_id": csq_record[prediction_index_map["feature"]],
-                "feature_type": {
-                    "accession_id": csq_record[prediction_index_map["feature_type"]]               
+                "feature_type": {  
+                    "value": csq_record[prediction_index_map["feature_type"]]     
                 } ,
                 "consequences": consequences_list,
                 "gene_stable_id" : csq_record[prediction_index_map["gene"]], 
@@ -285,7 +285,8 @@ class VariantAllele():
             return {
                 "feature": feature,
                 "feature_type": {
-                    "accession_id": feature_type                
+                    "value": feature_type   
+
                 } ,
                 "phenotype": {
                     "name": phenotype_name

--- a/common/file_model/variant_allele.py
+++ b/common/file_model/variant_allele.py
@@ -116,7 +116,7 @@ class VariantAllele():
         consequences_list = []
         if "consequence" in prediction_index_map.keys():
             for cons in csq_record[prediction_index_map["consequence"]].split("&"):
-                if cons in ["downstream_gene_variant", "upstream_gene_variant", "intergenic_variant"]:
+                if cons in ["downstream_gene_variant", "upstream_gene_variant", "intergenic_variant", "regulatory_region_variant"]:
                     consequences_list = []
                     break
                 consequences_list.append(
@@ -173,20 +173,13 @@ class VariantAllele():
             cdna_start = cdna_position_list[0]
             cdna_end = cdna_start if len(cdna_position_list) < 2 else cdna_position_list[0]
             cdna_length = int(cdna_end) - int(cdna_start) + 1
-            relation = {
-                "label": "overlaps",
-                "definition": "Overlaps with the feature"
-
-            }
             percentage_overlap = 100
             ref_sequence = self.reference_sequence
             alt_sequence = csq_record[prediction_index_map["allele"]]
             cdna_location = {
-                "relation": relation,
                 "start": cdna_start,
                 "end": cdna_end, 
                 "length": cdna_length, 
-                "percentage_overlap": percentage_overlap ,
                 "ref_sequence": ref_sequence,
                 "alt_sequence": alt_sequence
             }
@@ -199,20 +192,13 @@ class VariantAllele():
             cds_start = cds_position_list[0]
             cds_end = cds_start if len(cds_position_list) < 2 else cds_position_list[0]
             cds_length = int(cds_end) - int(cds_start) + 1
-            relation = {
-                "label": "overlaps",
-                "definition": "Overlaps with the feature"
-
-            }
             percentage_overlap = 100
             ref_sequence = codons.split("/")[0]
             alt_sequence = codons.split("/")[1]
             cds_location = {
-                "relation": relation,
                 "start": cds_start,
                 "end": cds_end, 
                 "length": cds_length, 
-                "percentage_overlap": percentage_overlap ,
                 "ref_sequence": ref_sequence,
                 "alt_sequence": alt_sequence
             }
@@ -225,20 +211,13 @@ class VariantAllele():
             protein_start = protein_position_list[0]
             protein_end = protein_start if len(protein_position_list) < 2 else protein_position_list[0]
             protein_length = int(protein_end) - int(protein_start) + 1
-            relation = {
-                "label": "overlaps",
-                "definition": "Overlaps with the feature"
-
-            }
             percentage_overlap = 100
             ref_sequence = amino_acids.split("/")[0]
             alt_sequence = amino_acids.split("/")[1]
             protein_location = {
-                "relation": relation,
                 "start": protein_start,
                 "end": protein_end, 
                 "length": protein_length, 
-                "percentage_overlap": percentage_overlap,
                 "ref_sequence": ref_sequence,
                 "alt_sequence": alt_sequence
             }

--- a/common/file_model/variant_allele.py
+++ b/common/file_model/variant_allele.py
@@ -307,6 +307,6 @@ class VariantAllele():
         elif len(alt) < len(self.reference_sequence):
             minimised_allele_string = "-"
         elif alt == self.reference_sequence:
-            minimised_allele_string = alt[1:]
+            minimised_allele_string = alt[1:] if len(alt) > 1 else "-"
         return minimised_allele_string
     

--- a/common/file_model/variant_allele.py
+++ b/common/file_model/variant_allele.py
@@ -128,6 +128,7 @@ class VariantAllele():
         return (position_start,position_end,position_length)
     
     def create_allele_predicted_molecular_consequence(self, csq_record: List, prediction_index_map: dict) -> Mapping:
+        feature_type = csq_record[prediction_index_map["feature_type"]]
         consequences_list = []
         if "consequence" in prediction_index_map.keys():
             for cons in csq_record[prediction_index_map["consequence"]].split("&"):
@@ -239,13 +240,13 @@ class VariantAllele():
                 "ref_sequence": ref_protein_sequence,
                 "alt_sequence": alt_protein_sequence
             }
-        
-        if consequences_list:
+
+        if consequences_list and feature_type == "Transcript":
             return {
                 "allele_name": csq_record[prediction_index_map["allele"]],
                 "stable_id": csq_record[prediction_index_map["feature"]],
                 "feature_type": {  
-                    "value": csq_record[prediction_index_map["feature_type"]]     
+                    "value":    feature_type  
                 } ,
                 "consequences": consequences_list,
                 "gene_stable_id" : csq_record[prediction_index_map["gene"]], 

--- a/common/file_model/variant_allele.py
+++ b/common/file_model/variant_allele.py
@@ -116,6 +116,9 @@ class VariantAllele():
         consequences_list = []
         if "consequence" in prediction_index_map.keys():
             for cons in csq_record[prediction_index_map["consequence"]].split("&"):
+                if cons in ["downstream_gene_variant", "upstream_gene_variant", "intergenic_variant"]:
+                    consequences_list = []
+                    break
                 consequences_list.append(
                     {
                         "accession_id": cons

--- a/common/file_model/variant_allele.py
+++ b/common/file_model/variant_allele.py
@@ -173,7 +173,6 @@ class VariantAllele():
             cdna_start = cdna_position_list[0]
             cdna_end = cdna_start if len(cdna_position_list) < 2 else cdna_position_list[0]
             cdna_length = int(cdna_end) - int(cdna_start) + 1
-            percentage_overlap = 100
             ref_sequence = self.reference_sequence
             alt_sequence = csq_record[prediction_index_map["allele"]]
             cdna_location = {
@@ -192,7 +191,6 @@ class VariantAllele():
             cds_start = cds_position_list[0]
             cds_end = cds_start if len(cds_position_list) < 2 else cds_position_list[0]
             cds_length = int(cds_end) - int(cds_start) + 1
-            percentage_overlap = 100
             ref_sequence = codons.split("/")[0]
             alt_sequence = codons.split("/")[1]
             cds_location = {
@@ -211,7 +209,6 @@ class VariantAllele():
             protein_start = protein_position_list[0]
             protein_end = protein_start if len(protein_position_list) < 2 else protein_position_list[0]
             protein_length = int(protein_end) - int(protein_start) + 1
-            percentage_overlap = 100
             ref_sequence = amino_acids.split("/")[0]
             alt_sequence = amino_acids.split("/")[1]
             protein_location = {

--- a/common/file_model/variant_allele.py
+++ b/common/file_model/variant_allele.py
@@ -306,7 +306,7 @@ class VariantAllele():
             minimised_allele_string = alt[1:] 
         elif len(alt) < len(self.reference_sequence):
             minimised_allele_string = "-"
-        elif alt == self.reference_sequence:
+        elif alt == self.reference_sequence and len(self.alt) != len(self.reference_sequence):
             minimised_allele_string = alt[1:] if len(alt) > 1 else "-"
         return minimised_allele_string
     

--- a/common/file_model/variant_allele.py
+++ b/common/file_model/variant_allele.py
@@ -171,7 +171,7 @@ class VariantAllele():
         if cdna_position:
             cdna_position_list  = cdna_position.split("-")
             cdna_start = cdna_position_list[0]
-            cdna_end = cdna_start if len(cdna_position_list) < 2 else cdna_position_list[0]
+            cdna_end = cdna_start if len(cdna_position_list) < 2 else cdna_position_list[1]
             cdna_length = int(cdna_end) - int(cdna_start) + 1
             ref_sequence = self.reference_sequence
             alt_sequence = csq_record[prediction_index_map["allele"]]
@@ -189,7 +189,7 @@ class VariantAllele():
         if cds_position:
             cds_position_list  = cds_position.split("-")
             cds_start = cds_position_list[0]
-            cds_end = cds_start if len(cds_position_list) < 2 else cds_position_list[0]
+            cds_end = cds_start if len(cds_position_list) < 2 else cds_position_list[1]
             cds_length = int(cds_end) - int(cds_start) + 1
             ref_sequence = codons.split("/")[0]
             alt_sequence = codons.split("/")[1]
@@ -207,7 +207,7 @@ class VariantAllele():
         if protein_position:
             protein_position_list  = protein_position.split("-")
             protein_start = protein_position_list[0]
-            protein_end = protein_start if len(protein_position_list) < 2 else protein_position_list[0]
+            protein_end = protein_start if len(protein_position_list) < 2 else protein_position_list[1]
             protein_length = int(protein_end) - int(protein_start) + 1
             ref_sequence = amino_acids.split("/")[0]
             alt_sequence = amino_acids.split("/")[1]

--- a/common/file_model/variant_allele.py
+++ b/common/file_model/variant_allele.py
@@ -129,10 +129,14 @@ class VariantAllele():
         if "sift" in prediction_index_map.keys():
             sift_score = csq_record[prediction_index_map["sift"]]
             if sift_score:
-                (result, score) = self.format_sift_polyphen_output(sift_score)
-                if result is not None and score is not None:
+                (label, score) = self.format_sift_polyphen_output(sift_score)
+                if label is not None and score is not None:
+                    classification = {
+                        "label": label,
+                        "definition": ""
+                    }
                     sift_prediction_result = {
-                            "result": result,
+                            "classification": classification,
                             "score": score,
                             "analysis_method": {
                                 "tool": "SIFT",
@@ -144,10 +148,14 @@ class VariantAllele():
         if "polyphen" in prediction_index_map.keys():
             polyphen_score = csq_record[prediction_index_map["polyphen"]]
             if polyphen_score:
-                (result, score) = self.format_sift_polyphen_output(polyphen_score)
-                if result is not None and score is not None:
+                (label, score) = self.format_sift_polyphen_output(polyphen_score)
+                if label is not None and score is not None:
+                    classification = {
+                        "label": label,
+                        "definition": ""
+                    }
                     polyphen_prediction_result = {
-                            "result": result,
+                            "classification": classification,
                             "score": score,
                             "analysis_method": {
                                 "tool": "PolyPhen",
@@ -165,7 +173,11 @@ class VariantAllele():
             cdna_start = cdna_position_list[0]
             cdna_end = cdna_start if len(cdna_position_list) < 2 else cdna_position_list[0]
             cdna_length = int(cdna_end) - int(cdna_start) + 1
-            relation = "overlaps"
+            relation = {
+                "label": "overlaps",
+                "definition": "Overlaps with the feature"
+
+            }
             percentage_overlap = 100
             ref_sequence = self.reference_sequence
             alt_sequence = csq_record[prediction_index_map["allele"]]
@@ -213,7 +225,11 @@ class VariantAllele():
             protein_start = protein_position_list[0]
             protein_end = protein_start if len(protein_position_list) < 2 else protein_position_list[0]
             protein_length = int(protein_end) - int(protein_start) + 1
-            relation = "overlaps"
+            relation = {
+                "label": "overlaps",
+                "definition": "Overlaps with the feature"
+
+            }
             percentage_overlap = 100
             ref_sequence = amino_acids.split("/")[0]
             alt_sequence = amino_acids.split("/")[1]
@@ -222,7 +238,7 @@ class VariantAllele():
                 "start": protein_start,
                 "end": protein_end, 
                 "length": protein_length, 
-                "percentage_overlap": percentage_overlap ,
+                "percentage_overlap": percentage_overlap,
                 "ref_sequence": ref_sequence,
                 "alt_sequence": alt_sequence
             }
@@ -242,7 +258,7 @@ class VariantAllele():
                 "prediction_results": prediction_results,
                 "cdna_location": cdna_location,
                 "cds_location": cds_location,
-                "protein_position": protein_location
+                "protein_location": protein_location
             }
             
 

--- a/common/schemas/metadata.graphql
+++ b/common/schemas/metadata.graphql
@@ -13,6 +13,15 @@ interface XrefMetadata {
 }
 
 
+type ValueSet implements ValueSetMetadata {
+	accession_id: String
+	label: String!
+	value: String
+	is_current: Boolean
+	definition: String!
+	description: String
+}
+
 type OntologyTermMetadata {
     # Temp solution: Nullable because some xrefs doesnt have xref accession id eg: PF3D7_1314600
 	accession_id: String

--- a/common/schemas/predicted_molecular_consequence.graphql
+++ b/common/schemas/predicted_molecular_consequence.graphql
@@ -9,7 +9,7 @@ type PredictedMolecularConsequence{
   prediction_results: [PredictionResult]
   gene_stable_id: String!
   gene_symbol: String!
-  protein_stable_id: String!
+  protein_stable_id: String
   transcript_biotype: String!
   cdna_location: VariantRelativeLocation
   cds_location: VariantRelativeLocation

--- a/common/schemas/predicted_molecular_consequence.graphql
+++ b/common/schemas/predicted_molecular_consequence.graphql
@@ -11,7 +11,7 @@ type PredictedMolecularConsequence{
   gene_symbol: String!
   protein_stable_id: String!
   transcript_biotype: String!
-  cdna_location: VariantRelativeLocation
+  cdna_location: VariantRelativeLocation!
   cds_location: VariantRelativeLocation
   protein_location: VariantRelativeLocation 
 }

--- a/common/schemas/predicted_molecular_consequence.graphql
+++ b/common/schemas/predicted_molecular_consequence.graphql
@@ -21,11 +21,11 @@ type VariantRelativeLocation{
   VariantRelativeLocation
 """
   relation: ValueSet
-  start: Int!
-  end: Int!
-  length: Int!
+  start: Int
+  end: Int
+  length: Int
   percentage_overlap: Float
-  ref_sequence: String!
-  alt_sequence: String!
+  ref_sequence: String
+  alt_sequence: String
   
 }

--- a/common/schemas/predicted_molecular_consequence.graphql
+++ b/common/schemas/predicted_molecular_consequence.graphql
@@ -3,10 +3,29 @@ type PredictedMolecularConsequence{
   PredictedMolecularConsequence
 """
   allele_name: String!
-  feature_stable_id: String!
+  stable_id: String!
   feature_type: OntologyTermMetadata!
   consequences: [OntologyTermMetadata]!
   prediction_results: [PredictionResult]
-  ## variant_representation
-  ## relative_locations
+  gene_stable_id: String!
+  gene_symbol: String!
+  protein_stable_id: String!
+  transcript_biotype: String!
+  cdna_location: VariantRelativeLocation
+  cds_location: VariantRelativeLocation
+  protein_location: VariantRelativeLocation 
+}
+
+type VariantRelativeLocation{
+"""
+  VariantRelativeLocation
+"""
+  relation: ValueSetMetadata!
+  start: Int!
+  end: Int!
+  length: Int!
+  percentage_overlap: Float!
+  ref_sequence: String!
+  alt_sequence: String!
+  
 }

--- a/common/schemas/predicted_molecular_consequence.graphql
+++ b/common/schemas/predicted_molecular_consequence.graphql
@@ -20,7 +20,7 @@ type VariantRelativeLocation{
 """
   VariantRelativeLocation
 """
-  relation: ValueSetMetadata!
+  relation: ValueSet!
   start: Int!
   end: Int!
   length: Int!

--- a/common/schemas/predicted_molecular_consequence.graphql
+++ b/common/schemas/predicted_molecular_consequence.graphql
@@ -11,7 +11,7 @@ type PredictedMolecularConsequence{
   gene_symbol: String!
   protein_stable_id: String!
   transcript_biotype: String!
-  cdna_location: VariantRelativeLocation!
+  cdna_location: VariantRelativeLocation
   cds_location: VariantRelativeLocation
   protein_location: VariantRelativeLocation 
 }
@@ -20,11 +20,11 @@ type VariantRelativeLocation{
 """
   VariantRelativeLocation
 """
-  relation: ValueSet!
+  relation: ValueSet
   start: Int!
   end: Int!
   length: Int!
-  percentage_overlap: Float!
+  percentage_overlap: Float
   ref_sequence: String!
   alt_sequence: String!
   

--- a/common/schemas/prediction_result.graphql
+++ b/common/schemas/prediction_result.graphql
@@ -15,6 +15,6 @@ type PredictionResult {
 """ 
   score: Float
   result: String
-  classification: ValueSetMetadata
+  classification: ValueSet
   analysis_method: AnalysisMethod
 }


### PR DESCRIPTION
Ticket: [ENSVAR-6169](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6169)

- [x] Populate `prediction_result->classification` instead of `prediction_result->result`
- [x] Parse `variant_relative_location->relation` and  `variant_relative_location->percentage_overlap` correctly: _we do not need to parse them currently as they are relevant to structural variants_
- [x] Filtering out consequences (`upstream_gene_variant`, `downstream_gene_variant`, `intergenic_variant`, `regulatory_region_variant`), does that make sense? `cdna_location` is  empty for these consequences: _cdna_location needs to be a nullable field to incorporate intron variants_
- [x]  Handle "?" in cdna, cds, protein positions
- [x] Allele frequency precision to 3 significant figures
- [x] Return only Transcript features
- [x] Bug fix to length in `variant_relative_location`
- [x] Test examples