### PR TITLE
Parsing amino acids when there is single sequence

### DIFF
--- a/common/file_model/variant_allele.py
+++ b/common/file_model/variant_allele.py
@@ -245,8 +245,9 @@ class VariantAllele():
         if protein_position:
             protein_start, protein_end, protein_length = self.parse_position(protein_position)
             if (protein_start != None and protein_end != None):
-                ref_protein_sequence = amino_acids.split("/")[0]
-                alt_protein_sequence = amino_acids.split("/")[1]
+                amino_acids_array = amino_acids.split("/")
+                ref_protein_sequence = amino_acids_array[0]
+                alt_protein_sequence = amino_acids_array[1] if len(amino_acids_array)>1 else amino_acids_array[0]
             protein_location = {
                 "start": protein_start,
                 "end": protein_end, 


### PR DESCRIPTION
Bug with parsing when amino_acid from the data file returns a single string instead of `ref_sequence`/`alt_sequence`

#### Examples
21:10649400:rs771244603 (coding_sequence_variant&incomplete_terminal_codon_variant)
2:178454479:rs745471025 (coding_sequence_variant&NMD_transcript_variant)
MT:8529:rs267606881 (synonymous variant)

#### Solution
Return the same string for `ref_sequence` and `alt_sequence`


#### Questions
Does the solution make sense for all the consequence types?

