### PR TITLE
Fix parsing INFO SOURCE containing space

### DIFF
--- a/common/file_model/variant.py
+++ b/common/file_model/variant.py
@@ -105,6 +105,7 @@ class Variant():
                 source = self.header.get_lines("source")[0].value
 
             # Get source information from data file header header
+            source = source.strip('"').replace(" ", "_")
             genome_uuid = self.genome_uuid
             if genome_uuid not in self.variant_sources or source not in self.variant_sources[genome_uuid]:     
                 self.parse_source_from_header()


### PR DESCRIPTION
The PR handles if there is whitespace in INFO SOURCE

Testing: 

```
query variant_example {
  variant(
    by_id: {genome_id: "a73357ab-93e7-11ec-a39d-005056b38ce3", variant_id: "4D:15781314:Cadenza1761.chr4D.15781314"}
  ) {
      name
      primary_source {
        url
        source {
          name
          release
        }
      }
    }
}
```